### PR TITLE
chore: add initial repo configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Node modules
+node_modules/
+
+# Build outputs
+dist/
+build/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment files
+.env
+.env.*
+!.env.example
+
+# Misc
+.DS_Store
+*.tsbuildinfo
+coverage/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "repricer-app",
+  "version": "0.0.0",
+  "private": true,
+  "workspaces": [
+    "apps/api",
+    "apps/web",
+    "packages/shared",
+    "infrastructure"
+  ],
+  "scripts": {
+    "dev": "turbo dev",
+    "build": "turbo build",
+    "lint": "turbo lint",
+    "test": "turbo test"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "eslint": "^8.57.0",
+    "prettier": "^3.2.5",
+    "turbo": "^1.10.12"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold monorepo root package.json with workspaces and dev scripts
- add shared dev dependencies for TypeScript, ESLint, Prettier and Turborepo
- include base .gitignore and .editorconfig

## Testing
- `npm test` *(fails: turbo not found)*
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c008f016e48328aecc261d8b9ba951